### PR TITLE
`mlxtend` v0.23.1 Update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlxtend" %}
-{% set version = "0.22.0" %}
+{% set version = "0.23.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bab0a9b28b5ffc5254fb73dc68f12fdab44215bc6b097ea3cc78d6bb7f10c47a
+  sha256: 9f3075e3deac57f4452fee2c1f0befda58a24c1f9c26bed649a2303ca04baa29
 
 build:
   number: 0


### PR DESCRIPTION
## mlxtend v0.23.1 

Destination channel: defaults

### Links:
[PKG-3786](https://anaconda.atlassian.net/browse/PKG-3786)
[Upstream repository](https://github.com/rasbt/mlxtend)

### Explanation of Changes:
- Bump version
- SHA update


[PKG-3786]: https://anaconda.atlassian.net/browse/PKG-3786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ